### PR TITLE
fix grpc outputfolder quoting in Exec line

### DIFF
--- a/Grpc.Tools.MsBuild.Core/build/Grpc.Tools.MsBuild.Unofficial.targets
+++ b/Grpc.Tools.MsBuild.Core/build/Grpc.Tools.MsBuild.Unofficial.targets
@@ -51,7 +51,7 @@
       <GrpcProtocExec Condition="'$(GrpcProtocExec)' == ''">$([System.IO.Path]::Combine($(GrpcToolsPath), $(_GrpcToolsSubFolderName), $(GrpcProtocExecName)))</GrpcProtocExec>
     </PropertyGroup>
     <MakeDir Directories="$(_GrpcOutputFolder)" />
-    <Exec Command="$(GrpcProtocExec) $(GrpcAdditionalArguments) @(NormalizedProtoIncludeFolder -> '-I%(Identity)', ' ') @(GrpcIncludeFolders -> '-I%(Identity)', ' ') --csharp_out=$(_GrpcOutputFolder) --grpc_out=$(_GrpcOutputFolder) @(NormalizedProtoFile -> '%(Identity)', ' ') --plugin=protoc-gen-grpc=$(GrpcCSharpPluginExec)" />
+    <Exec Command="$(GrpcProtocExec) $(GrpcAdditionalArguments) @(NormalizedProtoIncludeFolder -> '-I%(Identity)', ' ') @(GrpcIncludeFolders -> '-I%(Identity)', ' ') --csharp_out=&quot;$(_GrpcOutputFolder)&quot; --grpc_out=&quot;$(_GrpcOutputFolder)&quot; @(NormalizedProtoFile -> '%(Identity)', ' ') --plugin=protoc-gen-grpc=$(GrpcCSharpPluginExec)" />
   </Target>
 
   <Target Name="GenerateGrpcFiles"


### PR DESCRIPTION
When _GrpcOutputFolder contains spaces (like "Any CPU"), the exec line fails due to the missing quotes.

Possibly related to #9.